### PR TITLE
Replace userType and currentTime with correct values

### DIFF
--- a/lib/PowerAPI/Data/Student.php
+++ b/lib/PowerAPI/Data/Student.php
@@ -73,8 +73,8 @@ class Student extends BaseObject
                 'serverInfo' => (object) Array(
                     'apiVersion' => $this->soap_session->serverInfo->apiVersion
                 ),
-                'serverCurrentTime' => '2012-12-26T21:47:23.792Z', # I really don't know.
-                'userType' => '2'
+                'serverCurrentTime' => $this->soap_session->serverCurrentTime,
+                'userType' => $this->soap_session->userType
             ),
             'studentIDs' => $this->soap_session->studentIDs,
             'qil' => (object) Array(

--- a/lib/PowerAPI/PowerAPI.php
+++ b/lib/PowerAPI/PowerAPI.php
@@ -32,11 +32,10 @@ class PowerAPI
         ));
 
         $login = $client->__call(
-            'login',
+            'loginToPublicPortal',
             Array(
                 'username' => $username,
-                'password' => $password,
-                'userType' => 2
+                'password' => $password
             )
         );
 


### PR DESCRIPTION
Replace userType with correct value to allow parents' account login

Note: I don't know if it is the correct setting for `serverCurrentTime` but it makes more sense than the original one.